### PR TITLE
feat: add metadata, accessibility, terms pages, and development modal

### DIFF
--- a/src/app/accesibilidad/page.tsx
+++ b/src/app/accesibilidad/page.tsx
@@ -1,0 +1,208 @@
+import HeroSubSection from "../../modules/layout/Hero";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Accesibilidad",
+  description:
+    "Políticas de accesibilidad del Consejo General de Educación (CGE) en Corrientes",
+};
+
+export default function AccesibilidadPage() {
+  return (
+    <main className="min-h-screen">
+      <HeroSubSection
+        title="Políticas de Accesibilidad"
+        description="Nuestro compromiso con la accesibilidad web"
+      />
+
+      <div className="container mx-auto px-4 py-8">
+        <div className="max-w-4xl mx-auto">
+          <section className="prose prose-lg max-w-none">
+            <h2 className="text-2xl font-semibold mb-4 text-gray-800">
+              Nuestro Compromiso
+            </h2>
+            <p className="mb-6">
+              El Consejo General de Educación de Corrientes se compromete a
+              garantizar la accesibilidad de su sitio web para todas las
+              personas, independientemente de sus capacidades o discapacidades.
+              Trabajamos continuamente para asegurar que todos los usuarios
+              puedan acceder a la información y servicios de manera efectiva y
+              eficiente.
+            </p>
+
+            <h2 className="text-2xl font-semibold mb-4 text-gray-800">
+              Navegación por Teclado
+            </h2>
+            <p className="mb-4">
+              Nuestro sitio web está completamente optimizado para la navegación
+              por teclado. Los usuarios pueden:
+            </p>
+            <ul className="list-disc pl-6 mb-6">
+              <li>
+                Utilizar la tecla{" "}
+                <kbd className="px-2 py-1 bg-gray-100 rounded border border-gray-300">
+                  Tab
+                </kbd>{" "}
+                para navegar secuencialmente por todos los elementos
+                interactivos
+              </li>
+              <li>
+                Usar{" "}
+                <kbd className="px-2 py-1 bg-gray-100 rounded border border-gray-300">
+                  Shift + Tab
+                </kbd>{" "}
+                para navegar en dirección inversa
+              </li>
+              <li>
+                Activar enlaces y botones con la tecla{" "}
+                <kbd className="px-2 py-1 bg-gray-100 rounded border border-gray-300">
+                  Enter
+                </kbd>
+              </li>
+              <li>
+                Utilizar las teclas de flecha para navegar dentro de menús
+                desplegables
+              </li>
+              <li>
+                Presionar{" "}
+                <kbd className="px-2 py-1 bg-gray-100 rounded border border-gray-300">
+                  Esc
+                </kbd>{" "}
+                para cerrar diálogos o menús
+              </li>
+            </ul>
+
+            <h3 className="text-xl font-semibold mb-3 text-gray-800">
+              Atajos de Teclado Principales
+            </h3>
+            <div className="mb-6">
+              <ul className="list-none pl-0 space-y-2">
+                <li>
+                  <kbd className="px-2 py-1 bg-gray-100 rounded border border-gray-300">
+                    Alt + 1
+                  </kbd>{" "}
+                  - Ir al contenido principal
+                </li>
+                <li>
+                  <kbd className="px-2 py-1 bg-gray-100 rounded border border-gray-300">
+                    Alt + 2
+                  </kbd>{" "}
+                  - Ir al menú de navegación
+                </li>
+                <li>
+                  <kbd className="px-2 py-1 bg-gray-100 rounded border border-gray-300">
+                    Alt + 3
+                  </kbd>{" "}
+                  - Ir al pie de página
+                </li>
+                <li>
+                  <kbd className="px-2 py-1 bg-gray-100 rounded border border-gray-300">
+                    Alt + S
+                  </kbd>{" "}
+                  - Ir al buscador
+                </li>
+              </ul>
+            </div>
+
+            <h2 className="text-2xl font-semibold mb-4 text-gray-800">
+              Estándares de Accesibilidad
+            </h2>
+            <p className="mb-4">
+              Nuestro sitio web sigue las pautas de accesibilidad WCAG 2.1 nivel
+              AA y cumple con la normativa vigente. Implementamos las siguientes
+              medidas:
+            </p>
+            <ul className="list-disc pl-6 mb-6">
+              <li>Navegación mediante teclado completa y visible</li>
+              <li>
+                Compatibilidad con lectores de pantalla (NVDA, JAWS, VoiceOver)
+              </li>
+              <li>Alto contraste y tipografía legible con tamaño ajustable</li>
+              <li>Textos alternativos descriptivos en todas las imágenes</li>
+              <li>Estructura semántica del contenido con landmarks ARIA</li>
+              <li>Subtítulos y transcripciones para contenido multimedia</li>
+              <li>
+                Formularios con etiquetas claras y mensajes de error accesibles
+              </li>
+            </ul>
+
+            <h2 className="text-2xl font-semibold mb-4 text-gray-800">
+              Adaptación Visual
+            </h2>
+            <p className="mb-4">
+              Para mejorar la legibilidad, ofrecemos las siguientes
+              características:
+            </p>
+            <ul className="list-disc pl-6 mb-6">
+              <li>Contraste suficiente entre texto y fondo (mínimo 4.5:1)</li>
+              <li>
+                Posibilidad de aumentar el tamaño del texto hasta un 200% sin
+                pérdida de funcionalidad
+              </li>
+              <li>Espaciado consistente entre elementos</li>
+              <li>Fuentes legibles y ajustables</li>
+              <li>Sin contenido que parpadee o destelle</li>
+            </ul>
+
+            <h2 className="text-2xl font-semibold mb-4 text-gray-800">
+              Compatibilidad con Tecnologías de Asistencia
+            </h2>
+            <p className="mb-4">
+              Nuestro sitio es compatible con las siguientes tecnologías:
+            </p>
+            <ul className="list-disc pl-6 mb-6">
+              <li>
+                Lectores de pantalla modernos (NVDA, JAWS, VoiceOver, TalkBack)
+              </li>
+              <li>Software de reconocimiento de voz</li>
+              <li>Magnificadores de pantalla</li>
+              <li>Dispositivos de entrada alternativos</li>
+            </ul>
+
+            <h2 className="text-2xl font-semibold mb-4 text-gray-800">
+              Reportar Problemas
+            </h2>
+            <p className="mb-6">
+              Si encuentra alguna dificultad para acceder a nuestro contenido o
+              desea reportar un problema de accesibilidad, por favor contáctenos
+              a través de nuestra{" "}
+              <a href="/contacto" className="text-primary hover:underline">
+                sección de contacto
+              </a>
+              . Nos comprometemos a:
+            </p>
+            <ul className="list-disc pl-6 mb-6">
+              <li>Responder a su consulta dentro de las 48 horas hábiles</li>
+              <li>
+                Proporcionar la información en formatos alternativos si es
+                necesario
+              </li>
+              <li>Resolver los problemas de accesibilidad lo antes posible</li>
+              <li>Mantenerle informado sobre el progreso de la resolución</li>
+            </ul>
+
+            <h2 className="text-2xl font-semibold mb-4 text-gray-800">
+              Mejora Continua
+            </h2>
+            <p className="mb-6">
+              Trabajamos constantemente para mejorar la accesibilidad de nuestro
+              sitio web mediante:
+            </p>
+            <ul className="list-disc pl-6 mb-6">
+              <li>Auditorías regulares de accesibilidad</li>
+              <li>
+                Pruebas con usuarios que utilizan tecnologías de asistencia
+              </li>
+              <li>
+                Capacitación continua de nuestro equipo en mejores prácticas de
+                accesibilidad
+              </li>
+              <li>Actualización de tecnologías y estándares</li>
+              <li>Incorporación de feedback de usuarios</li>
+            </ul>
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/contacto/page.tsx
+++ b/src/app/contacto/page.tsx
@@ -25,6 +25,13 @@ import HeroSubSection from "../../modules/layout/Hero";
 import FAQSection from "../../modules/layout/FAQSection";
 import { useContactForm } from "../../modules/contact/hooks/useContactForm";
 import { faqsContact } from "../../modules/faqs/faqs";
+// import { Metadata } from "next";
+
+// export const metadata: Metadata = {
+//   title: "Contacto",
+//   description:
+//     "Si tienes alguna consulta o sugerencia, no dudes en contactarnos. Estamos aquí para ayudarte.",
+// };
 export default function Contacto() {
   const { form, enviado, error, buttonState, onSubmit } = useContactForm();
 

--- a/src/app/documentacion/page.tsx
+++ b/src/app/documentacion/page.tsx
@@ -4,6 +4,13 @@ import HeroSubSection from "../../modules/layout/Hero";
 import FAQSection from "../../modules/layout/FAQSection";
 import { Suspense } from "react";
 import { faqsDocs } from "../../modules/faqs/faqs";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Documentación",
+  description:
+    "Documentación del Consejo General de Educación (CGE) en Corrientes",
+};
 
 export default function Documentacion() {
   return (

--- a/src/app/institucional/page.tsx
+++ b/src/app/institucional/page.tsx
@@ -10,6 +10,13 @@ import {
 } from "lucide-react";
 import HeroSubSection from "../../modules/layout/Hero";
 import CarouselInstitucional from "../../components/CarouselInstitucional";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Institucional",
+  description:
+    "Conoce la historia, funciones y contacto del Consejo General de Educación (CGE) en Corrientes",
+};
 
 export default function Institucional() {
   return (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import "./index.css";
 import Footer from "../modules/layout/Footer";
 import Header from "../modules/layout/Header";
 import { Lora, Inter } from "next/font/google";
+import ModalAvisoDesarrollo from "../components/ModalAvisoDesarrollo";
 
 import metadata from "./metadata";
 import Head from "next/head";
@@ -45,6 +46,7 @@ export default function RootLayout({
       </Head>
       <body className={`${inter.className} antialiased`}>
         <Header />
+        <ModalAvisoDesarrollo />
         <div id="root">{children}</div>
         <Footer />
       </body>

--- a/src/app/noticias/page.tsx
+++ b/src/app/noticias/page.tsx
@@ -3,6 +3,13 @@ import { getAllContent } from "../../modules/article/data/content";
 import { Info, Phone } from "lucide-react";
 import PageWithFAQ from "../../modules/layout/PageWithFAQ";
 import { faqsNews } from "../../modules/faqs/faqs";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Noticias",
+  description:
+    "Noticias y novedades del Consejo General de Educación (CGE) en Corrientes",
+};
 
 export default function NoticiasGrid() {
   const rawNoticias = getAllContent("noticias");

--- a/src/app/terminos/page.tsx
+++ b/src/app/terminos/page.tsx
@@ -1,0 +1,83 @@
+import HeroSubSection from "../../modules/layout/Hero";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Terminos y Condiciones",
+  description:
+    "Terminos y Condiciones de Uso del Sitio Web del Consejo General de Educación (CGE) en Corrientes",
+};
+
+export default function Terminos() {
+  return (
+    <main className="min-h-screen">
+      <HeroSubSection
+        title="Términos y Condiciones"
+        description="Información legal y condiciones de uso del sitio web del CGE Corrientes"
+      />
+      <div className="container mx-auto px-4 py-8">
+        <div className="max-w-4xl mx-auto">
+          <section className="prose prose-lg max-w-none">
+            <h2 className="text-2xl font-semibold mb-4 text-gray-800">
+              Sitio oficial del CGE
+            </h2>
+            <p className="mb-6">
+              Este sitio web es una plataforma oficial del Consejo General de
+              Educación (CGE), dependiente del Ministerio de Educación de la
+              Provincia de Corrientes, República Argentina.
+            </p>
+            <h2 className="text-2xl font-semibold mb-4 text-gray-800">
+              1. Uso del sitio
+            </h2>
+            <p className="mb-6">
+              El contenido de este sitio tiene como objetivo brindar información
+              pública relacionada con la educación en la provincia de
+              Corrientes. Su acceso es libre y gratuito.
+            </p>
+            <h2 className="text-2xl font-semibold mb-4 text-gray-800">
+              2. Reproducción del contenido
+            </h2>
+            <p className="mb-6">
+              Se permite la reproducción total o parcial de los contenidos
+              publicados en este sitio, siempre que se cite la fuente y no se
+              altere su significado o integridad.
+            </p>
+            <h2 className="text-2xl font-semibold mb-4 text-gray-800">
+              3. Protección de datos personales
+            </h2>
+            <p className="mb-6">
+              Este sitio no recolecta datos personales de los usuarios. No se
+              utilizan formularios que soliciten información identificable ni se
+              aplican tecnologías de rastreo que comprometan la privacidad.
+            </p>
+            <h2 className="text-2xl font-semibold mb-4 text-gray-800">
+              4. Responsabilidad sobre la información
+            </h2>
+            <p className="mb-6">
+              El CGE se compromete a mantener actualizada y precisa la
+              información publicada. Sin embargo, no se garantiza la ausencia
+              total de errores involuntarios o desactualización temporal. En
+              caso de duda, se recomienda contactar al organismo de forma
+              oficial.
+            </p>
+            <h2 className="text-2xl font-semibold mb-4 text-gray-800">
+              5. Enlaces externos
+            </h2>
+            <p className="mb-6">
+              El sitio puede contener enlaces a páginas externas que pertenecen
+              a otros organismos o entidades. El CGE no se responsabiliza por el
+              contenido ni por la disponibilidad de dichos sitios.
+            </p>
+            <h2 className="text-2xl font-semibold mb-4 text-gray-800">
+              6. Jurisdicción
+            </h2>
+            <p className="mb-6">
+              Toda controversia derivada de la interpretación o aplicación de
+              los presentes términos será sometida a la jurisdicción de los
+              tribunales ordinarios de la Provincia de Corrientes.
+            </p>
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/tramites/page.tsx
+++ b/src/app/tramites/page.tsx
@@ -3,7 +3,13 @@ import { getAllContent } from "../../modules/article/data/content";
 import { Info, Phone } from "lucide-react";
 import PageWithFAQ from "../../modules/layout/PageWithFAQ";
 import { faqsTramites } from "../../modules/faqs/faqs";
-import { info } from "console";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Trámites y Gestiones",
+  description:
+    "Portal centralizado de trámites del Consejo General de Educación (CGE) en Corrientes",
+};
 
 export default function TramitesGrid() {
   const rawTramites = getAllContent("tramites");

--- a/src/components/ModalAvisoDesarrollo.tsx
+++ b/src/components/ModalAvisoDesarrollo.tsx
@@ -1,0 +1,36 @@
+"use client";
+import React, { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "./ui/dialog";
+
+export default function ModalAvisoDesarrollo() {
+  const [open, setOpen] = useState(false);
+  useEffect(() => {
+    if (
+      typeof window !== "undefined" &&
+      !sessionStorage.getItem("modalShown")
+    ) {
+      setOpen(true);
+      sessionStorage.setItem("modalShown", "true");
+    }
+  }, []);
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>¡Sitio en desarrollo!</DialogTitle>
+          <DialogDescription>
+            Esta página se encuentra en desarrollo. Los contenidos pueden
+            variar, estar incompletos o cambiar sin previo aviso. Gracias por tu
+            comprensión.
+          </DialogDescription>
+        </DialogHeader>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/modules/layout/Footer.tsx
+++ b/src/modules/layout/Footer.tsx
@@ -198,6 +198,21 @@ const Footer = () => {
             </a>
           </div>
         </div>
+        <div className="flex flex-col md:flex-row justify-center items-center mt-6 gap-2">
+          <Link
+            href="/accesibilidad"
+            className="text-xs text-white/70 hover:text-white underline transition-colors mx-2"
+          >
+            Accesibilidad
+          </Link>
+          <span className="hidden md:inline text-white/40">|</span>
+          <Link
+            href="/terminos"
+            className="text-xs text-white/70 hover:text-white underline transition-colors mx-2"
+          >
+            Términos de uso
+          </Link>
+        </div>
       </div>
     </footer>
   );


### PR DESCRIPTION
Add metadata to institutional, documentation, news, and procedures pages for SEO. Introduce new accessibility and terms of use pages with detailed content. Implement a development modal to inform users about the site's ongoing development status. Update footer with links to accessibility and terms pages.